### PR TITLE
Update CI action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,9 @@ on:
     branches:
       - master
       - 'v*'
-  pull_request: {}
-  schedule:
-    - cron:  '0 3 * * *' # daily, at 3am
+  pull_request:
+    branches:
+      - master
 
 jobs:
   lint:


### PR DESCRIPTION
This PR will remove the scheduled trigger for the CI action and add in another trigger to run the linting and testing whenever there is a new PR trying to merge into master